### PR TITLE
pin msgpack to <1.4.0

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -49,6 +49,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch-api:5.0.5' \
      'elasticsearch:5.0.5' \
      'prometheus-client:0.9.0' \
+     'msgpack:<1.4.0' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:1.17.2' \
      'fluent-plugin-record-modifier:0.6.2' \


### PR DESCRIPTION
1.4.0 is incompatible with used ruby version